### PR TITLE
LIBAVALON-211. Use an env variable instead of a positional param for dry run.

### DIFF
--- a/lib/tasks/umd.rake
+++ b/lib/tasks/umd.rake
@@ -2,13 +2,14 @@ require 'move_dropbox_files_to_archive'
 
 namespace :umd do
   desc "Move master files from dropbox directory to archive"
-  task :move_dropbox_files_to_archive, %i[dry_run] => :environment do |_t, args|
-    args.with_defaults(:dry_run => 'false')
-
+  task :move_dropbox_files_to_archive => :environment do
     archive_dir = Settings.master_file_management.path
     raise '"path" configuration missing for master_file_management strategy "move"' if archive_dir.blank?
 
-    dry_run = ActiveModel::Type::Boolean.new.cast(args.dry_run)
+    # additionally support "no" as a false boolean value
+    ENV['dry_run'] = 'false' if ENV['dry_run'].in? %w[no NO]
+
+    dry_run = ActiveModel::Type::Boolean.new.cast(ENV['dry_run'])
 
     Rails.logger.tagged("move_dropbox_files_to_archive") do
       Rails.logger.info("Starting move_dropbox_files_to_archive, dry_run=#{dry_run}")


### PR DESCRIPTION
Reasoning:

* Makes the command line more expressive: `rails umd:move_dropbox_files_to_archive dry_run=yes` vs. `rails umd:move_dropbox_files_to_archive[true]`
* Aligns this task's parameter passing behavior with the existing avalon tasks (see e.g. `rails avalon:user:create avalon_username=... avalon_password=...`)

Added additional logic so that "no" and "NO" are also recognized as false values.

https://issues.umd.edu/browse/LIBAVALON-211